### PR TITLE
Add support for Django 1.4 timezone support

### DIFF
--- a/fluent_pages/models/managers.py
+++ b/fluent_pages/models/managers.py
@@ -1,7 +1,13 @@
 """
 The manager class for the CMS models
 """
-from datetime import datetime
+try:
+    from django.utils.timezone import now
+except ImportError:
+    # The timezone support was introducted in Django 1.4, fallback to standard
+    # library for 1.3.
+    from datetime import datetime
+    now = datetime.now
 from django.db.models.query_utils import Q
 from polymorphic_tree.managers import PolymorphicMPTTModelManager, PolymorphicMPTTQuerySet
 from fluent_pages.utils.db import DecoratingQuerySet
@@ -51,10 +57,10 @@ class UrlNodeQuerySet(PolymorphicMPTTQuerySet, DecoratingQuerySet):
             .filter(status=UrlNode.PUBLISHED) \
             .filter(
                 Q(publication_date__isnull=True) |
-                Q(publication_date__lt=datetime.now())
+                Q(publication_date__lt=now())
             ).filter(
                 Q(publication_end_date__isnull=True) |
-                Q(publication_end_date__gte=datetime.now())
+                Q(publication_end_date__gte=now())
             )
 
 


### PR DESCRIPTION
This adds support for timezones that was introduced in Django 1.4. If you set USE_TZ to True with Django 1.4 you will get a warning when using datetime.now from the standard library because it returns a naive datetime without timezone information. Django provides django.utils.timezone.now that returns a non-naive datetime when USE_TZ is set to True.

For more information about Django 1.4 timezone support and why it's important, I recommend Aymeric Augustin excellent talk at DjangoCon EU 2012:

http://lanyrd.com/2012/djangocon-europe/srptc/
