### PR TITLE
Modify _get_current_page to handle an invalid 'page' in context

### DIFF
--- a/fluent_pages/templatetags/fluent_pages_tags.py
+++ b/fluent_pages/templatetags/fluent_pages_tags.py
@@ -165,11 +165,7 @@ def _get_current_page(context):
                                            "- No context variable named 'page' found.")
 
         if not isinstance(current_page, UrlNode):
-            try:
-                current_page = UrlNode.objects.get_for_path(request.path)
-            except UrlNode.DoesNotExist:
-                current_site = Site.objects.get_current()
-                current_page = UrlNode(title='', in_navigation=False, override_url=request.path, status=UrlNode.DRAFT, parent_site=current_site)
+            raise UrlNode.DoesNotExist("The 'page' context variable is not a valid page")
 
         request._current_fluent_page = current_page
 


### PR DESCRIPTION
In the project we're currently building out with django-fluent-pages we have a global footer that renders menus from our pages. We use `get_fluent_page_vars` in our template to ensure that the 'page' & 'site' variables are always in context.

We just recently integrated haystack searching into the site and ran into a problem when accessing the search results. The exception we received was:

```
'Page' object has no attribute 'parent_site'
```

This is because haystack uses its own variable named 'page' in the context that it uses for pagination. When our call to `get_fluent_page_vars` happened it saw the existing page variable and thus just blindly used it.

This change ensures that the object being assigned to `request._current_fluent_page` is actually a `UrlNode` object, and if not then it will try to look it up using the request path and fall back to a dummy page exactly the same as it does elsewhere in the template tags.
