### PR TITLE
Get the previous parent id if it is available on save.

### DIFF
--- a/fluent_pages/models/db.py
+++ b/fluent_pages/models/db.py
@@ -292,6 +292,10 @@ class UrlNode(PolymorphicMPTTModel, TranslatableModel):
         """
         Save the model, and update caches.
         """
+        # None is valid here so use 0 which is not valid
+        previous_parent_id = kwargs.get('previous_parent_id', 0)
+        if previous_parent_id is None or previous_parent_id > 0:
+            self._original_parent = previous_parent_id
         parent_changed = self.parent_id != self._original_parent
         if parent_changed:
             self._mark_all_translations_dirty()


### PR DESCRIPTION
This is in case _original_parent becomes unreliable.
This depends on a pull request in django-polymorphic-tree:
https://github.com/edoburu/django-polymorphic-tree/pull/17
