### PR TITLE
Protect against NoneType value in prepare_value.

### DIFF
--- a/fluent_pages/forms/fields.py
+++ b/fluent_pages/forms/fields.py
@@ -28,14 +28,15 @@ class TemplateFilePathField(forms.FilePathField):
         """
         Allow effortlessly switching between relative and absolute paths.
         """
-        if appsettings.FLUENT_PAGES_RELATIVE_TEMPLATE_DIR:
-            # Turn old absolute paths into relative paths.
-            if value and os.path.isabs(value) and value.startswith(self.path):
-                value = value[len(self.path):].lstrip('/')
-        else:
-            # If setting is disabled, turn relative path back to abs.
-            if not os.path.isabs(value):
-                value = os.path.join(self.path, value)
+        if value is not None:
+            if appsettings.FLUENT_PAGES_RELATIVE_TEMPLATE_DIR:
+                # Turn old absolute paths into relative paths.
+                if os.path.isabs(value) and value.startswith(self.path):
+                    value = value[len(self.path):].lstrip('/')
+            else:
+                # If setting is disabled, turn relative path back to abs.
+                if not os.path.isabs(value):
+                    value = os.path.join(self.path, value)
         return value
 
 


### PR DESCRIPTION
There was no NoneType protection when FLUENT_PAGES_RELATIVE_TEMPLATE_DIR was False.
