### PR TITLE
Add ability to restrict children on add type admin page.

### DIFF
--- a/fluent_pages/admin/urlnodeparentadmin.py
+++ b/fluent_pages/admin/urlnodeparentadmin.py
@@ -87,6 +87,7 @@ class UrlNodeParentAdmin(TranslatableAdmin, PolymorphicMPTTParentModelAdmin):
         """
         Return a list of polymorphic types which can be added.
         """
+        # The arguments are made optional, to support both django-polymorphic 0.5 and 0.6
         from fluent_pages.extensions import page_type_pool
 
         can_have_children = None


### PR DESCRIPTION
Based on https://github.com/edoburu/django-polymorphic-tree/pull/24

Probably needs django-polymorphic >= 0.6 due to its use of
get_child_type_choices(self, request, action).

Fixes #31
