### PR TITLE
Convert byte strings to strings in migrations.

### DIFF
--- a/fluent_pages/pagetypes/flatpage/migrations/0001_initial.py
+++ b/fluent_pages/pagetypes/flatpage/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             name='FlatPage',
             fields=[
                 ('urlnode_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='fluent_pages.UrlNode')),
-                ('template_name', models.CharField(default=b'fluent_pages/pagetypes/flatpage/default.html', max_length=200, null=True, editable=False, verbose_name='Layout')),
+                ('template_name', models.CharField(default='fluent_pages/pagetypes/flatpage/default.html', max_length=200, null=True, editable=False, verbose_name='Layout')),
                 ('content', models.TextField(verbose_name='Content', blank=True)),
             ],
             options={

--- a/fluent_pages/pagetypes/textfile/migrations/0001_initial.py
+++ b/fluent_pages/pagetypes/textfile/migrations/0001_initial.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('urlnode_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='fluent_pages.UrlNode')),
                 ('content', models.TextField(verbose_name='File contents')),
-                ('content_type', models.CharField(default=b'text/plain', max_length=100, verbose_name='File type', choices=[(b'text/plain', 'Plain text'), (b'text/xml', 'XML'), (b'text/html', 'HTML')])),
+                ('content_type', models.CharField(default='text/plain', max_length=100, verbose_name='File type', choices=[('text/plain', 'Plain text'), ('text/xml', 'XML'), ('text/html', 'HTML')])),
             ],
             options={
                 'db_table': 'pagetype_textfile_textfile',


### PR DESCRIPTION
I needed this change when I converted a project from Python 2.7 to Python 3.4.

See:
https://code.djangoproject.com/ticket/23226