### PR TITLE
Fix migrations for Django 1.11.

### DIFF
--- a/fluent_pages/integration/fluent_contents/models.py
+++ b/fluent_pages/integration/fluent_contents/models.py
@@ -4,7 +4,9 @@ Everything can be imported from ``__init__.py``.
 """
 from __future__ import absolute_import
 
+import django
 from django.utils.translation import ugettext_lazy as _
+
 from fluent_contents.models import Placeholder
 from fluent_contents.models.fields import ContentItemRelation, PlaceholderRelation
 from fluent_pages.models import HtmlPage
@@ -25,8 +27,9 @@ class FluentContentsPage(HtmlPage):
     #: Related manager to access all content items
     contentitem_set = ContentItemRelation()
 
-    # As this is an abstract model, the default manager is reset in Django 1.10.
-    objects = UrlNodeManager()
+    # The default manager is reset in Django 1.10.
+    if django.VERSION >= (1, 10):
+        objects = UrlNodeManager()
 
     class Meta:
         abstract = True

--- a/fluent_pages/models/db.py
+++ b/fluent_pages/models/db.py
@@ -132,9 +132,6 @@ class UrlNode(with_metaclass(URLNodeMetaClass, PolymorphicMPTTModel, Translatabl
             ('change_shared_fields_urlnode', _("Can change Shared fields")),     # The fields shared between languages.
             ('change_override_url_urlnode', _("Can change Override URL field")),  # Fpr overriding URLs (e.g. '/' for homepage).
         )
-        if django.VERSION >= (1, 10):
-            # Although likely not needed, this helps making things explicit.
-            default_manager_name = 'objects'
 
 #    class MPTTMeta:
 #        order_insertion_by = 'title'

--- a/fluent_pages/pagetypes/flatpage/models.py
+++ b/fluent_pages/pagetypes/flatpage/models.py
@@ -1,6 +1,9 @@
+import django
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_wysiwyg.utils import clean_html, sanitize_html
+
+from fluent_pages.models.managers import UrlNodeManager
 from fluent_pages.models import HtmlPage
 from fluent_pages.pagetypes.flatpage import appsettings
 
@@ -15,6 +18,10 @@ class FlatPage(HtmlPage):
 
     # Other fields, such as "registration_required" are not reused,
     # because these should be implemented globally in the base page model, or a pluggable authorization layer.
+
+    # The default manager is reset in Django 1.10.
+    if django.VERSION >= (1, 10):
+        objects = UrlNodeManager()
 
     class Meta:
         verbose_name = _("Flat Page")

--- a/fluent_pages/pagetypes/flatpage/tests.py
+++ b/fluent_pages/pagetypes/flatpage/tests.py
@@ -1,0 +1,12 @@
+from fluent_pages.models import UrlNodeManager
+from fluent_pages.pagetypes.flatpage.models import FlatPage
+from fluent_pages.tests.utils import AppTestCase
+
+
+class FlatPageTests(AppTestCase):
+
+    def test_default_manager(self):
+        """
+        Test that the default manager is correct.
+        """
+        self.assertIsInstance(FlatPage._default_manager, UrlNodeManager)

--- a/fluent_pages/pagetypes/fluentpage/models.py
+++ b/fluent_pages/pagetypes/fluentpage/models.py
@@ -1,7 +1,10 @@
+import django
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+
+from fluent_pages.models.managers import UrlNodeManager
 from fluent_pages.integration.fluent_contents.models import FluentContentsPage
-from fluent_pages.models import PageLayout, UrlNodeManager
+from fluent_pages.models import PageLayout
 
 
 # This all exists for backwards compatibility
@@ -23,8 +26,9 @@ class AbstractFluentPage(FluentContentsPage):
     # Allow NULL in the layout, so this system can still be made optional in the future in favor of a configuration setting.
     layout = models.ForeignKey(PageLayout, verbose_name=_('Layout'), null=True)
 
-    # As this is an abstract model, the default manager is reset in Django 1.10.
-    objects = UrlNodeManager()
+    # The default manager is reset in Django 1.10.
+    if django.VERSION >= (1, 10):
+        objects = UrlNodeManager()
 
     class Meta:
         abstract = True

--- a/fluent_pages/pagetypes/redirectnode/models.py
+++ b/fluent_pages/pagetypes/redirectnode/models.py
@@ -1,5 +1,8 @@
+import django
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+
+from fluent_pages.models.managers import UrlNodeManager
 from fluent_pages.models import Page
 from fluent_utils.softdeps.any_urlfield import AnyUrlField
 from parler.models import TranslatedFields
@@ -21,6 +24,10 @@ class RedirectNode(Page):
         new_url=AnyUrlField(_("New URL"), max_length=255),
         redirect_type=models.IntegerField(_("Redirect type"), choices=REDIRECT_TYPE_CHOICES, default=302, help_text=_("Use 'normal redirect' unless you want to transfer SEO ranking to the new page.")),
     )
+
+    # The default manager is reset in Django 1.10.
+    if django.VERSION >= (1, 10):
+        objects = UrlNodeManager()
 
     class Meta:
         # If this page class didn't exist as real model before,

--- a/fluent_pages/pagetypes/redirectnode/tests.py
+++ b/fluent_pages/pagetypes/redirectnode/tests.py
@@ -1,0 +1,12 @@
+from fluent_pages.models import UrlNodeManager
+from fluent_pages.pagetypes.redirectnode.models import RedirectNode
+from fluent_pages.tests.utils import AppTestCase
+
+
+class RedirectNodeTests(AppTestCase):
+
+    def test_default_manager(self):
+        """
+        Test that the default manager is correct.
+        """
+        self.assertIsInstance(RedirectNode._default_manager, UrlNodeManager)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py27-django{17,18,19,110},
+    py27-django{17,18,19,110,111},
     py33-django{17,18},
-    py34-django{17,18,19,110},
+    py34-django{17,18,19,110,111},
     # py33-django-dev,
     coverage,
     docs,
@@ -17,8 +17,10 @@ deps =
     django19: django-mptt >= 0.8.0, != 0.8.5
     django110: Django >= 1.10,<1.11
     django110: django-mptt >= 0.8.4, != 0.8.5
+    django111: Django >= 1.11,<2.0
+    django111: django-mptt >= 0.8.4, != 0.8.5
     django-dev: https://github.com/django/django/tarball/master
-    django-any-url >= 2.2
+    django-any-urlfield >= 2.2
     django-wysiwyg >= 0.7.1
     django-fluent-contents >= 1.1
 commands=


### PR DESCRIPTION
I'm not sure if this is the correct thing to do but it does stop the migrations from being generated in the fluent-pages app.